### PR TITLE
Bump error_prone to 2.4.0. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <java.jdk.version>1.7</java.jdk.version>
 
         <!-- Build system and static code analysis -->
-        <linters.errorprone.version>2.3.2</linters.errorprone.version>
+        <linters.errorprone.version>2.4.0</linters.errorprone.version>
         <linters.spotbugs.plugin.version>4.0.0</linters.spotbugs.plugin.version>
         <linters.spotbugs.core.version>4.0.3</linters.spotbugs.core.version>
         <linters.pmd.version>3.13.0</linters.pmd.version>
@@ -114,14 +114,6 @@
                                     <groupId>org.codehaus.plexus</groupId>
                                     <artifactId>plexus-compiler-javac-errorprone</artifactId>
                                     <version>2.8.6</version>
-                                </dependency>
-                                <dependency>
-                                    <!--
-                                    Override plexus-compiler-javac-errorprone's dependency with the latest version
-                                    -->
-                                    <groupId>com.google.errorprone</groupId>
-                                    <artifactId>error_prone_core</artifactId>
-                                    <version>${linters.errorprone.version}</version>
                                 </dependency>
                             </dependencies>
                             <!-- /error_prone on jdk1.8 -->

--- a/src/main/java/com/tguzik/value/StringValue.java
+++ b/src/main/java/com/tguzik/value/StringValue.java
@@ -15,13 +15,13 @@ import org.apache.commons.lang3.StringUtils;
  * @since 0.1
  */
 @Immutable
-public abstract class StringValue extends Value<String> implements Comparable<Value<String>> {
+public abstract class StringValue extends Value<String> implements Comparable<StringValue> {
     protected StringValue( @Nullable final String value ) {
         super( value );
     }
 
     @Override
-    public int compareTo( @Nonnull final Value<String> other ) {
+    public int compareTo( @Nonnull final StringValue other ) {
         Objects.requireNonNull( other, "Parameter cannot be null." );
 
         if ( other == this ) {

--- a/src/test/java/com/tguzik/value/StringValueTest.java
+++ b/src/test/java/com/tguzik/value/StringValueTest.java
@@ -3,6 +3,8 @@ package com.tguzik.value;
 import static java.lang.Integer.signum;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -126,13 +128,13 @@ public class StringValueTest {
      * Contract per {@link java.lang.Comparable}:
      * throws ClassCastException if the specified object's type prevents it from being compared to this object.
      */
-    @SuppressWarnings( "unchecked" )
     @Test( expected = ClassCastException.class )
     public void compareTo_throws_ClassCastException_when_parameter_was_of_incompatible_type() {
-        final Value<Integer> integerValue = new Value<Integer>( Integer.valueOf( 123 ) ) {
-        };
+        final StringValue integerValue = mock(StringValue.class);
+        doReturn( 42 ).when( integerValue ).get();
 
-        a.compareTo( (Value) integerValue );
+
+        a.compareTo( integerValue );
     }
 
     /**


### PR DESCRIPTION
* Bump error_prone to 2.4.0. 
* Fix the issue it found in StringValue + fixup unit test. 
* Remove dependency override for javac-with-errorprone for jdk8 as it fails on jdk8.