### PR TITLE
ci: Add JDK25 to CI matrix, pin Actions to specific commits

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: ci-using-devenv
     strategy:
       matrix:
-        jdk_version: [ 17, 21 ]
+        jdk_version: [ 17, 21, 25 ]
 
     name: "JDK ${{ matrix.jdk_version }}"
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,14 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
-      - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
         with:
           nix_path: nixpkgs=channel:nixos-25.11
 
@@ -33,7 +39,7 @@ jobs:
       - name: Build, run tests, run static analysis
         shell: devenv shell bash -- -e {0}
         run: |
-          task build
+          mvn clean verify
 
   check-supported-jdks:
     needs: ci-using-devenv
@@ -44,8 +50,14 @@ jobs:
     name: "JDK ${{ matrix.jdk_version }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # https://github.com/actions/setup-java/releases/tag/v5.2.0
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: "Set up JDK ${{ matrix.jdk_version }}"
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # https://github.com/actions/setup-java/releases/tag/v5.2.0
         with:
           distribution: "temurin"
           java-version: ${{ matrix.jdk_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,9 +13,9 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v16
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # https://github.com/cachix/cachix-action/releases/tag/v16
         with:
           name: devenv
 
@@ -38,8 +38,8 @@ jobs:
     name: "JDK ${{ matrix.jdk_version }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # https://github.com/actions/setup-java/releases/tag/v5.2.0
         with:
           distribution: "temurin"
           java-version: ${{ matrix.jdk_version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
       - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
+        with:
+          nix_path: nixpkgs=channel:nixos-25.11
+
       - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # https://github.com/cachix/cachix-action/releases/tag/v16
         with:
           name: devenv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,19 +18,22 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-25.11
 
-      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # https://github.com/cachix/cachix-action/releases/tag/v16
-        with:
-          name: devenv
+      - name: Print nixpkgs version
+        run: |
+          nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
       - name: Install devenv.sh
-        run: nix profile install nixpkgs#devenv
+        run: |
+          nix profile add github:cachix/devenv/v1.11.1 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
 
       - name: Run devenv test
-        run: devenv test
+        run: |
+          devenv test
 
       - name: Build, run tests, run static analysis
         shell: devenv shell bash -- -e {0}
-        run: mvn clean verify
+        run: |
+          task build
 
   check-supported-jdks:
     needs: ci-using-devenv

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -29,12 +29,13 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-25.11
 
-      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # https://github.com/cachix/cachix-action/releases/tag/v16
-        with:
-          name: devenv
+      - name: Print nixpkgs version
+        run: |
+          nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
       - name: Install devenv.sh
-        run: nix profile install nixpkgs#devenv
+        run: |
+          nix profile add github:cachix/devenv/v1.11.1 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
 
       - name: Generate change list
         shell: devenv shell bash -- -e {0}

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -16,7 +16,7 @@ jobs:
       # Needed by softprops/action-gh-release to create the GitHub Release entry:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           persist-credentials: false
           clean: true
@@ -25,9 +25,8 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: cachix/install-nix-action@v31
-
-      - uses: cachix/cachix-action@v16
+      - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
+      - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # https://github.com/cachix/cachix-action/releases/tag/v16
         with:
           name: devenv
 
@@ -47,7 +46,7 @@ jobs:
           cat changes.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub Release entry
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # https://github.com/softprops/action-gh-release/releases/tag/v2.5.0
         if: github.ref_type == 'tag'
         with:
           # Populate the release entry body with the notes we generated

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -26,6 +26,9 @@ jobs:
           fetch-tags: true
 
       - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
+        with:
+          nix_path: nixpkgs=channel:nixos-25.11
+
       - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # https://github.com/cachix/cachix-action/releases/tag/v16
         with:
           name: devenv

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -16,7 +16,8 @@ jobs:
       # Needed by softprops/action-gh-release to create the GitHub Release entry:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           persist-credentials: false
           clean: true
@@ -25,7 +26,8 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
+      - name: Install Nix
+        uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
         with:
           nix_path: nixpkgs=channel:nixos-25.11
 

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,15 +3,16 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1763136231,
+        "lastModified": 1764115230,
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "4b8c2bbdb4e01ef8c4093ee1224fe21ed5ea1a5e",
+        "rev": "51440964cd26a47e90064f9d59aa230a5cefc88b",
         "type": "github"
       },
       "original": {
         "dir": "src/modules",
         "owner": "cachix",
+        "ref": "51440964cd26a47e90064f9d59aa230a5cefc88b",
         "repo": "devenv",
         "type": "github"
       }
@@ -19,14 +20,14 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1761588595,
-        "owner": "edolstra",
+        "lastModified": 1767039857,
+        "owner": "NixOS",
         "repo": "flake-compat",
-        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "NixOS",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -38,14 +39,15 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1763032142,
+        "lastModified": 1772665116,
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "84255025dee4c8701a99fbff65ac3c9095952f99",
+        "rev": "39f53203a8458c330f61cc0759fe243f0ac0d198",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "39f53203a8458c330f61cc0759fe243f0ac0d198",
         "repo": "git-hooks.nix",
         "type": "github"
       }
@@ -72,10 +74,10 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763191728,
+        "lastModified": 1772736753,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d4c88323ac36805d09657d13a5273aea1b34f0c",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
         "type": "github"
       },
       "original": {
@@ -87,16 +89,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1761313199,
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "d1c30452ebecfc55185ae6d1c983c09da0c274ff",
+        "lastModified": 1772822230,
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
         "type": "github"
       },
       "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
+        "owner": "nixos",
+        "ref": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/devenv.nix
+++ b/devenv.nix
@@ -56,7 +56,7 @@
         extends: relaxed
         rules:
           line-length:
-            max: 150
+            max: 180
       '';
     };
   };

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 ---
 inputs:
+  devenv:
+    url: github:cachix/devenv?dir=src/modules&ref=51440964cd26a47e90064f9d59aa230a5cefc88b # v1.11.1 as of 2026-03-07
   nixpkgs:
-    url: github:cachix/devenv-nixpkgs/rolling
+    url: github:nixos/nixpkgs?ref=71caefce12ba78d84fe618cf61644dce01cf3a96 # latest commit on nixos-25.11 branch as of 2026-03-07
   git-hooks:
-    url: github:cachix/git-hooks.nix
+    url: github:cachix/git-hooks.nix?ref=39f53203a8458c330f61cc0759fe243f0ac0d198 # latest commit on main branch as of 2026-03-07
 
 # eof

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
           <version>2.21.0</version>
           <configuration>
             <!-- When scanning for upgrades ignore pre-release artifacts -->
-            <ignoredVersions>.*-M.*,.*-alpha.*</ignoredVersions>
+            <ignoredVersions>.*-M.*,.*-alpha.*,.*-rc.*,.*-b.*</ignoredVersions>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This PR:

* Adds JDK25 to the CI matrix to ensure tests still pass on this version
* Adds additional dependency pre-release version number patterns to the ignorelist
* Pins GitHub Actions to specific commits
* Pins DevEnv and nixpkgs versions to latest stable versions:
  * Sticking with DevEnv 1.11.1 until [latest bugfix releases from the 2.x line](https://github.com/cachix/devenv/releases) are available in the main channels - ran into a couple of issues with scrollback and GPG input capture in the interactive mode.
