### PR TITLE
ci: Adjust GHA workflow permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     commit-message:
       prefix: "deps(gha): "
 
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 5
+      default-days: 7
     commit-message:
       prefix: "deps: "
       prefix-development: "deps(test): "

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   ci-using-devenv:
     name: CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
@@ -54,7 +54,7 @@ jobs:
         jdk_version: [ 17, 21, 25 ]
 
     name: "JDK ${{ matrix.jdk_version }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           persist-credentials: false
-          clean: true
 
       - name: Install Nix
         uses: cachix/install-nix-action@2126ae7fc54c9df00dd18f7f18754393182c73cd # https://github.com/cachix/install-nix-action/releases/tag/v31.9.1
@@ -60,7 +59,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           persist-credentials: false
-          clean: true
 
       - name: "Set up JDK ${{ matrix.jdk_version }}"
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # https://github.com/actions/setup-java/releases/tag/v5.2.0
@@ -73,6 +71,7 @@ jobs:
 
       - name: Build, run tests, run static analysis
         shell: bash
-        run: mvn clean verify
+        run: |
+          mvn clean verify
 
 # eof

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,11 @@ on:
       - "master"
       - "main"
 
-# This workflow shouldn't need any special permissions, so let's disable them all
-# Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes-1
 permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci-using-devenv:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,11 +49,12 @@ jobs:
   check-supported-jdks:
     needs: ci-using-devenv
     strategy:
+      max-parallel: 1 # Avoid concurrency settings cancelling matrix builds
       matrix:
         jdk_version: [ 17, 21, 25 ]
 
     name: "JDK ${{ matrix.jdk_version }}"
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest # ubuntu-slim doesn't come with maven by default, and we want to avoid installing it in the workflow
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ on:
       - "master"
       - "main"
 
+# This workflow shouldn't need any special permissions, so let's disable them all
+# Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes-1
+permissions: {}
+
 jobs:
   ci-using-devenv:
     name: CI

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   release:
     name: Create GitHub Release entry
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write # Needed by softprops/action-gh-release to create the GitHub Release entry
     steps:

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           persist-credentials: false
-          clean: true
           #
           # Fetch full history, including tags, or otherwise the changelog generation will silently fail:
           fetch-depth: 0

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Create GitHub Release entry
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # https://github.com/softprops/action-gh-release/releases/tag/v2.5.0
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' && github.event_name == 'push'
         with:
           # Populate the release entry body with the notes we generated
           body_path: changes.md

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -1,6 +1,7 @@
 name: Release Changelog
 
 on:
+  workflow_dispatch:  # No additional yaml keys are necessary
   push:
     # Automatically create a GitHub Release entry when a tag that looks like a new release is pushed.
     # The tag pattern is defined in maven-release-plugin's settings in pom.xml authoritatively. The changelog
@@ -11,7 +12,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: rel-${{ github.workflow }}-${{ github.ref }}
+  group: rel-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -8,13 +8,18 @@ on:
     tags:
       - 'v[0-9]+.*'
 
+permissions: {}
+
+concurrency:
+  group: rel-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Create GitHub Release entry
     runs-on: ubuntu-latest
     permissions:
-      # Needed by softprops/action-gh-release to create the GitHub Release entry:
-      contents: write
+      contents: write # Needed by softprops/action-gh-release to create the GitHub Release entry
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # https://github.com/actions/checkout/releases/tag/v6.0.2

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -1,7 +1,7 @@
 name: Release Changelog
 
 on:
-  workflow_dispatch:  # No additional yaml keys are necessary
+  workflow_dispatch:  # For manual testing; No additional yaml keys are necessary
   push:
     # Automatically create a GitHub Release entry when a tag that looks like a new release is pushed.
     # The tag pattern is defined in maven-release-plugin's settings in pom.xml authoritatively. The changelog

--- a/devenv.nix
+++ b/devenv.nix
@@ -59,6 +59,7 @@
             max: 180
       '';
     };
+    zizmor.enable = true;
   };
 
   enterShell = ''


### PR DESCRIPTION
This PR:

* Adds [zizmor](https://github.com/zizmorcore/zizmor), a GitHub Actions static analyzer, to pre-commit hooks
* Applies fixes for zizmor's findings:
  * Lower permissions for the default CI workflow from defaults to none
  * Increase dependabot cooldown from 5 to 7 days
  * Define workflow concurrency settings and enable cancelling outdated builds
* Switch most jobs from the `ubuntu-latest` to the `ubuntu-slim` runner