### PR TITLE
deps: Bump com.github.spotbugs:spotbugs-maven-plugin from 4.9.8.2 to 4.9.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.8.2</version>
+          <version>4.9.8.3</version>
           <executions>
             <execution>
               <phase>verify</phase>


### PR DESCRIPTION
Manual update since dependabot is still in a cooldown