### PR TITLE
chore: Update DevEnv to v2.0.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install devenv.sh
         run: |
-          nix profile add github:cachix/devenv/v1.11.1 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
+          nix profile add github:cachix/devenv/v2.0.6 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
 
       - name: Run devenv test
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
-      - name: Install devenv.sh
+      - name: Install DevEnv
         env:
           LOCAL_DEVENV_REVISION: 55d2bb4a3cc710ba82cc8644f4419db3a802e1a4 # https://github.com/cachix/devenv/releases/tag/v2.0.6
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,10 @@ jobs:
           nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
       - name: Install devenv.sh
+        env:
+          LOCAL_DEVENV_REVISION: 55d2bb4a3cc710ba82cc8644f4419db3a802e1a4 # https://github.com/cachix/devenv/releases/tag/v2.0.6
         run: |
-          nix profile add github:cachix/devenv/v2.0.6 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
+          nix profile add "github:cachix/devenv/${LOCAL_DEVENV_REVISION}" --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
 
       - name: Run devenv test
         run: |

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -59,12 +59,9 @@ jobs:
           cat changes.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub Release entry
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # https://github.com/softprops/action-gh-release/releases/tag/v3.0.0
         if: github.ref_type == 'tag' && github.event_name == 'push'
-        with:
-          # Populate the release entry body with the notes we generated
-          body_path: changes.md
-          # A hooman still needs to push the butan
-          draft: true
+        shell: devenv shell bash -- -e {0}
+        run: |
+          gh release create --draft --notes-file changes.md --fail-on-no-commits
 
 # eof

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install devenv.sh
         run: |
-          nix profile add github:cachix/devenv/v1.11.1 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
+          nix profile add github:cachix/devenv/v2.0.6 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
 
       - name: Generate change list
         shell: devenv shell bash -- -e {0}

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -63,7 +63,8 @@ jobs:
         shell: devenv shell bash -- -e {0}
         env:
           GH_TOKEN: ${{ github.token }}
+          LOCAL_CURRENT_TAG: ${{ github.ref_name }}
         run: |
-          gh release create --draft --notes-file changes.md --fail-on-no-commits
+          gh release create --draft --notes-file changes.md --fail-on-no-commits "${LOCAL_CURRENT_TAG}"
 
 # eof

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -61,6 +61,8 @@ jobs:
       - name: Create GitHub Release entry
         if: github.ref_type == 'tag' && github.event_name == 'push'
         shell: devenv shell bash -- -e {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create --draft --notes-file changes.md --fail-on-no-commits
 

--- a/.github/workflows/release-entry.yaml
+++ b/.github/workflows/release-entry.yaml
@@ -40,9 +40,11 @@ jobs:
         run: |
           nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
 
-      - name: Install devenv.sh
+      - name: Install DevEnv
+        env:
+          LOCAL_DEVENV_REVISION: 55d2bb4a3cc710ba82cc8644f4419db3a802e1a4 # https://github.com/cachix/devenv/releases/tag/v2.0.6
         run: |
-          nix profile add github:cachix/devenv/v2.0.6 --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
+          nix profile add "github:cachix/devenv/${LOCAL_DEVENV_REVISION}" --accept-flake-config --option extra-substituters "https://devenv.cachix.org?trusted=true&priority=3"
 
       - name: Generate change list
         shell: devenv shell bash -- -e {0}

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,16 +3,17 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1764115230,
+        "lastModified": 1774168944,
+        "narHash": "sha256-i1G6n/7Z5fO9RhplzXQSTiLyh1Cs0GhoCoEStFLARtA=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "51440964cd26a47e90064f9d59aa230a5cefc88b",
+        "rev": "55d2bb4a3cc710ba82cc8644f4419db3a802e1a4",
         "type": "github"
       },
       "original": {
         "dir": "src/modules",
         "owner": "cachix",
-        "ref": "51440964cd26a47e90064f9d59aa230a5cefc88b",
+        "ref": "v2.0.6",
         "repo": "devenv",
         "type": "github"
       }
@@ -21,6 +22,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
         "repo": "flake-compat",
         "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
@@ -39,16 +41,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1772665116,
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "39f53203a8458c330f61cc0759fe243f0ac0d198",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
-        "ref": "39f53203a8458c330f61cc0759fe243f0ac0d198",
         "repo": "git-hooks.nix",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       }
     },
@@ -60,10 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762808025,
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
         "type": "github"
       },
       "original": {
@@ -74,10 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772736753,
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
         "type": "github"
       },
       "original": {
@@ -89,15 +94,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1772822230,
+        "lastModified": 1776734388,
+        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -106,10 +112,7 @@
       "inputs": {
         "devenv": "devenv",
         "git-hooks": "git-hooks",
-        "nixpkgs": "nixpkgs_2",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs": "nixpkgs_2"
       }
     }
   },

--- a/devenv.nix
+++ b/devenv.nix
@@ -22,6 +22,7 @@
     gnupg
 
     # Packages specific to the CI/CD pipeline
+    gh # https://cli.github.com/ # GitHub CLI tool
     git-cliff # https://github.com/orhun/git-cliff + https://git-cliff.org/docs/ # Highly customizable Changelog Generator
 
     # Packages for the local development loop

--- a/devenv.nix
+++ b/devenv.nix
@@ -21,14 +21,11 @@
     go-task
     gnupg
 
-    # Maven Daemon
-    # https://github.com/apache/maven-mvnd
-    mvnd
+    # Packages specific to the CI/CD pipeline
+    git-cliff # https://github.com/orhun/git-cliff + https://git-cliff.org/docs/ # Highly customizable Changelog Generator
 
-    # Highly customizable changelog generator
-    # https://github.com/orhun/git-cliff
-    # https://git-cliff.org/docs/
-    git-cliff
+    # Packages for the local development loop
+    mvnd # https://github.com/apache/maven-mvnd # Apache Maven Daemon
   ];
 
   git-hooks.hooks = {

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -2,10 +2,10 @@
 ---
 inputs:
   devenv:
-    url: github:cachix/devenv?dir=src/modules&ref=51440964cd26a47e90064f9d59aa230a5cefc88b # v1.11.1 as of 2026-03-07
+    url: github:cachix/devenv?dir=src/modules&ref=v2.0.6
   nixpkgs:
-    url: github:nixos/nixpkgs?ref=71caefce12ba78d84fe618cf61644dce01cf3a96 # latest commit on nixos-25.11 branch as of 2026-03-07
+    url: github:nixos/nixpkgs?ref=nixos-25.11
   git-hooks:
-    url: github:cachix/git-hooks.nix?ref=39f53203a8458c330f61cc0759fe243f0ac0d198 # latest commit on main branch as of 2026-03-07
+    url: github:cachix/git-hooks.nix?rev=3cfd774b0a530725a077e17354fbdb87ea1c4aad # latest commit on main branch as of 2026-04-24
 
 # eof

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -2,8 +2,10 @@
 ---
 inputs:
   devenv:
+    # Lockfile allows us to use the tag name here instead of full SHA
     url: github:cachix/devenv?dir=src/modules&ref=v2.0.6
   nixpkgs:
+    # Lockfile allows us to use the tag name here instead of full SHA
     url: github:nixos/nixpkgs?ref=nixos-25.11
   git-hooks:
     url: github:cachix/git-hooks.nix?rev=3cfd774b0a530725a077e17354fbdb87ea1c4aad # latest commit on main branch as of 2026-04-24

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.tguzik</groupId>
@@ -23,7 +24,7 @@
   <scm>
     <connection>scm:git:git@github.com:tguzik/valueclasses.git</connection>
     <developerConnection>scm:git:git@github.com:tguzik/valueclasses.git</developerConnection>
-    <url>git@github.com:tguzik/valueclasses.git</url>
+    <url>https://github.com/tguzik/valueclasses</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -67,6 +68,7 @@
       <build>
         <defaultGoal>
           clean
+          scm:validate
           release:clean
           release:prepare
           release:perform
@@ -390,6 +392,11 @@
             <signTag>true</signTag>
             <tagNameFormat>v@{project.version}</tagNameFormat>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-scm-plugin</artifactId>
+          <version>2.2.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR:

* Updates DevEnv to the latest release - v2.0.6:
  * Release notes: <https://github.com/cachix/devenv/releases/tag/v2.0.6>
  * In CI this version will be installed using the full commit SHA instead of a tag name - will bring that step of the CI pipeline up to parity with pinned actions enforced by zizmor.
* Updates the Release Changelog workflow to create the release entry using GH CLI instead of a third party action.
* Updates Maven config to validate SCM links right before the release.