### PR TITLE
chore: Update DevEnv flake inputs

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -3,17 +3,17 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1774168944,
-        "narHash": "sha256-i1G6n/7Z5fO9RhplzXQSTiLyh1Cs0GhoCoEStFLARtA=",
+        "lastModified": 1778705847,
+        "narHash": "sha256-EQnZCy7r4VMO6KDoytxHBa0mFbM1D9g1kaDfs/s0YZA=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "55d2bb4a3cc710ba82cc8644f4419db3a802e1a4",
+        "rev": "ea3d94ac9d6bf6a1313773170122ca4e2ef5a0be",
         "type": "github"
       },
       "original": {
         "dir": "src/modules",
         "owner": "cachix",
-        "ref": "v2.0.6",
+        "ref": "v2.1.2",
         "repo": "devenv",
         "type": "github"
       }
@@ -41,17 +41,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "master",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       }
     },
@@ -94,16 +94,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
+        "lastModified": 1782375420,
+        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
+        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -2,12 +2,13 @@
 ---
 inputs:
   devenv:
-    # Lockfile allows us to use the tag name here instead of full SHA
-    url: github:cachix/devenv?dir=src/modules&ref=v2.0.6
+    # Pinning to specific commit is done through lockfile, which is why this line can contain just the tag name
+    url: github:cachix/devenv?dir=src/modules&ref=v2.1.2
   nixpkgs:
-    # Lockfile allows us to use the tag name here instead of full SHA
-    url: github:nixos/nixpkgs?ref=nixos-25.11
+    # Pinning to specific commit is done through lockfile, which is why this line can contain just the tag name
+    url: github:nixos/nixpkgs?ref=nixos-26.05
   git-hooks:
-    url: github:cachix/git-hooks.nix?rev=3cfd774b0a530725a077e17354fbdb87ea1c4aad # latest commit on main branch as of 2026-04-24
+    # Pinning to specific commit is done through lockfile, which is why this line can contain just the branch name
+    url: github:cachix/git-hooks.nix?ref=master
 
 # eof


### PR DESCRIPTION
Bit overdue, but this PR updates DevEnv inputs to latest versions